### PR TITLE
Remove need to create temp file before sending image file to mindee

### DIFF
--- a/app/services/extract_text_from_receipt.rb
+++ b/app/services/extract_text_from_receipt.rb
@@ -1,39 +1,27 @@
+require 'uri'
+require 'net/http'
+require 'net/https'
+require 'mime/types'
+require 'open-uri'
+
 class ExtractTextFromReceipt < ApplicationService
+  MINDEE_API = "https://api.mindee.net/v1/products/mindee/expense_receipts/v5/predict"
+
   def initialize(url:)
     @url = url
   end
 
   def call
-    require 'open-uri'
-    require 'uri'
-    require 'net/http'
-    require 'net/https'
-    require 'mime/types'
-    require 'tempfile'
+    api = URI(MINDEE_API)
 
-    cloudinary_url = @url
-
-    url = URI("https://api.mindee.net/v1/products/mindee/expense_receipts/v5/predict")
-
-    cloudinary_file = URI.open(cloudinary_url)
-
-    temp_file = Tempfile.new(['temp', File.extname(cloudinary_url)], 'tmp')
-
-    temp_file.write(cloudinary_file.read.force_encoding(Encoding::UTF_8))
-
-    temp_file.rewind
-
-    http = Net::HTTP.new(url.host, url.port)
+    http = Net::HTTP.new(api.host, api.port)
     http.use_ssl = true
-    request = Net::HTTP::Post.new(url)
+
+    request = Net::HTTP::Post.new(api)
     request["Authorization"] = "Token #{ENV['RECEIPT_KEY']}"
-    request.set_form([['document', File.open(temp_file)]], 'multipart/form-data')
+    request.set_form([['document', URI.open(@url)]], 'multipart/form-data')
 
     response = http.request(request)
-
-    temp_file.close
-    temp_file.unlink
-
     JSON.parse(response.read_body)
   end
 end


### PR DESCRIPTION
I forgot how to 
parse and forward image data from an image url to an external api 
without creating a temp file.

And then I remembered.